### PR TITLE
Refine homepage layout and publication links

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -74,6 +74,12 @@ h3 {
   /*border-right: 1px dashed rgba(0, 0, 0, .2);*/
 }
 
+.publication-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
 .portfolio-item {
   border-bottom: 1px dashed rgba(0, 0, 0, .2);
 }

--- a/index.html
+++ b/index.html
@@ -39,29 +39,28 @@
     </header> -->
 
     <main role="main">
-    <div align="center">
 
       <section class="jumbotron header">
         <div class="col-md-8 row jumbotron-content">
         <div class="text-left col-md-9">
           <h1 class="jumbotron-heading text-center">Jing Yu <strong>Koh</strong></h1>
-          <p align="center">jingyuk@cs.cmu.edu</p>
+          <p class="text-center">jingyuk@cs.cmu.edu</p>
           <p>I am a research scientist at TBD Lab of Meta Superintelligence Labs. I lead the computer use agents team to develop general purpose agents that can automate computer work.</p>
           <p>I'm currently on a leave of absence from a PhD in machine learning at Carnegie Mellon University where I'm advised by <a href="https://dpfried.github.io" target="_blank">Daniel Fried</a> and <a href="https://www.cs.cmu.edu/~rsalakhu/index.html" target="_blank">Ruslan Salakhutdinov</a>. Prior to starting my  PhD, I worked at <a href="https://research.google" target="_blank">Google Research</a> in <a href="https://scholar.google.com/citations?user=TP_JZm8AAAAJ" target="_blank">Jason Baldridge</a>'s team from 2019-2022, where I researched vision-and-language problems and generative models. Before that, I completed my undergraduate studies at the <a href="https://sutd.edu.sg" target="_blank">Singapore University of Technology and Design</a> <i>summa cum laude</i> (highest honors) in 2019.</p>
 
           <p class="note">My first name is "Jing Yu" and informally I go by the nickname "JY". 许靖宇 is my name in Chinese. I'm from Singapore.</p>
         <div class="text-center">
           <p>
-            <a href="https://twitter.com/kohjingyu" target="_blank"><i class="fa fa-twitter contact-icon" aria-hidden="true"></i></a>
-            <a href="https://scholar.google.com/citations?user=iGLKl7cAAAAJ" target="_blank"><i class="ai ai-google-scholar contact-icon" aria-hidden="true"></i></a>
+            <a href="https://twitter.com/kohjingyu" target="_blank"><i class="fa fa-twitter contact-icon" aria-hidden="true">&nbsp;</i></a>
+            <a href="https://scholar.google.com/citations?user=iGLKl7cAAAAJ" target="_blank"><i class="ai ai-google-scholar contact-icon" aria-hidden="true">&nbsp;</i></a>
             <!-- <a href="https://github.com/kohjingyu" target="_blank"><i class="fa fa-github contact-icon" aria-hidden="true"></i></a> -->
             <!-- <a href="https://www.linkedin.com/in/kohjingyu/" target="_blank"><i class="fa fa-linkedin-square contact-icon" aria-hidden="true"></i></a> -->
-            <a href="mailto:jingyuk@cs.cmu.edu"><i class="fa fa-envelope contact-icon" aria-hidden="true"></i></a>
+            <a href="mailto:jingyuk@cs.cmu.edu"><i class="fa fa-envelope contact-icon" aria-hidden="true">&nbsp;</i></a>
           </p>
         </div>
         </div>
         <div class="col-md-3">
-        <img class="profile-img" src="images/photo.jpg">
+        <img class="profile-img" src="images/photo.jpg" alt="Jing Yu Koh">
         </div>
         </div>
       </section>
@@ -74,42 +73,41 @@
         <h2>News</h2>
         <hr>
         <ul>
-        <li><span class="news-date">(Jan 2025)</span> Gave an invited talk about Multimodal Computer Agents at Google DeepMind.</li>
-        <li><span class="news-date">(Aug 2024)</span> Gave invited talks about <a href="https://jykoh.com/search-agents" target="_blank">Tree Search for LM Agents</a> at UW, CMU, and Meta.</li>
-        <li><span class="news-date">(Jun 2024)</span> Personal update: I've joined the Llama team at Meta to build multimodal agents!</li>
-        <li><span class="news-date">(Jun 2024)</span> Excited to share a new preprint: <a href="https://jykoh.com/search-agents" target="_blank">Tree Search for Language Model Agents</a>.</li>
-        <li><span class="news-date">(Spring 2024)</span> Gave invited talks about <a href="https://jykoh.com/vwa" target="_blank">VisualWebArena</a> at NUS, Jane Street, and Cohere for AI (<a href="https://www.youtube.com/watch?v=PmWDEqkVnqg" target="_blank">recording</a>).</li>
-        <li><span class="news-date">(Feb 2024)</span> Awarded the <a href="https://www.janestreet.com/join-jane-street/programs-and-events/grf-profiles-2024/" target="_blank">Jane Street Graduate Research Fellowship</a>. Thank you Jane Street!</li>
-        <li><span class="news-date">(Jan 2024)</span> Excited to share a new preprint: <a href="https://jykoh.com/vwa" target="_blank">VisualWebArena: Evaluating Multimodal Agents on Realistic Visual Web Tasks</a>.</li>
-        <li><span class="news-date">(Sep 2023)</span> 1 paper accepted to <a href="https://neurips.cc" target="_blank">NeurIPS 2023</a>!</li>
-        <li><span class="news-date">(Summer 2023)</span> Gave an invited talk about <a href="/gill" target="_blank">GILL</a> at <a href="https://mlcollective.org/dlct/" target="_blank">DLCT</a> and <a href="https://cohere.for.ai/" target="_blank">Cohere For AI</a> (<a href="/gill/gill_talk.pdf" target="_blank">slides</a>, <a href="https://www.youtube.com/watch?v=aUoiQ4xFknQ" target="_blank">recording</a>).</li>
-        <li><span class="news-date">(Apr 2023)</span> 1 paper accepted to <a href="https://icml.cc" target="_blank">ICML 2023</a>!</li>
-        <li><span class="news-date">(Spring 2023)</span> Gave invited talks at Microsoft Research, Apple AI/ML, Georgia Tech, and the London ML Meetup (<a href="https://www.youtube.com/watch?v=WNIjb96GvxU" target="_blank">recording</a>, <a href="fromage/fromage_talk.pdf" target="_blank">slides</a>).</li>
-
-        <div class="wrap-collabsible">
-          <input id="collapsible" class="toggle" type="checkbox">
-          <label for="collapsible" class="lbl-toggle">Older news</label>
-          <div class="collapsible-content">
-            <div class="content-inner">
-        <!--         <li><span class="news-date">(Jan 2023)</span> <a href="https://arxiv.org/abs/2301.13823" target="_blank">New preprint</a>! We ground LLMs to enable multimodal processing and generation.</li>
-         -->        <li><span class="news-date">(Dec 2022)</span> I made a <a href="https://benchugg.com/writing/ai-bet/" target="_blank">bet on LLM capabilities</a> with my office mate Ben Chugg. Bubble tea is on the line.</li>
-                <!-- <li><span class="news-date">(Dec 2022)</span> 1 paper accepted to <a hef="https://aaai.org/Conferences/AAAI-23/" target="_blank">AAAI 2023</a>.</li> -->
-                <li><span class="news-date">(Nov 2022)</span> <a href="https://parti.research.google" target="_blank">Parti</a> was accepted to TMLR with a Featured Certification!</li>
-                <li><span class="news-date">(Oct 2022)</span> In the spirit of paying it forward, I'm sharing my <a href="jykoh_sop.pdf" target="_blank">Statement of Purpose</a> publicly. Hope it helps future applicants!</li>
-                <li><span class="news-date">(Jul 2022)</span> After 2.73 wonderful years at Google, I've left to pursue my PhD at Carnegie Mellon University!</li>
-                <li><span class="news-date">(January 2022)</span> 1 paper accepted to <a href="https://iclr.cc" target="_blank">ICLR 2022</a>!</li>
-                <li><span class="news-date">(December 2021)</span> Serving as a reviewer for <a href="https://cvpr2022.thecvf.com" target="_blank">CVPR 2022</a>.</li>
-                <li><span class="news-date">(July 2021)</span> 1 paper accepted to <a href="http://iccv2021.thecvf.com" target="_blank">ICCV 2021</a>!</li>
-                <li><span class="news-date">(July 2021)</span> Presenting an <a href="https://www.microsoft.com/en-us/research/video/grounded-visual-generation/" target="_blank">invited talk</a> at Microsoft Research.</li>
-                <li><span class="news-date">(July 2021)</span> Serving as a reviewer for <a href="https://nips.cc/Conferences/2021/" target="_blank">NeurIPS 2021</a>.</li>
-                <li><span class="news-date">(March 2021)</span> 1 paper accepted to <a href="http://cvpr2021.thecvf.com" target="_blank">CVPR 2021</a>!</li>
-                <li><span class="news-date">(January 2021)</span> 1 paper accepted to <a href="https://iclr.cc" target="_blank">ICLR 2021</a>!</li>
-                <li><span class="news-date">(October 2020)</span> 1 paper accepted to <a href="http://wacv2021.thecvf.com/" target="_blank">WACV 2021</a>!</li>
-                <li><span class="news-date">(July 2020)</span> 1 paper accepted to <a href="https://eccv2020.eu" target="_blank">ECCV 2020</a>!</li>
-                <li><span class="news-date">(October 2019)</span> Officially joined Google as an AI Resident in Mountain View, California.</li>
+          <li><span class="news-date">(Jan 2025)</span> Gave an invited talk about Multimodal Computer Agents at Google DeepMind.</li>
+          <li><span class="news-date">(Aug 2024)</span> Gave invited talks about <a href="https://jykoh.com/search-agents" target="_blank">Tree Search for LM Agents</a> at UW, CMU, and Meta.</li>
+          <li><span class="news-date">(Jun 2024)</span> Personal update: I've joined the Llama team at Meta to build multimodal agents!</li>
+          <li><span class="news-date">(Jun 2024)</span> Excited to share a new preprint: <a href="https://jykoh.com/search-agents" target="_blank">Tree Search for Language Model Agents</a>.</li>
+          <li><span class="news-date">(Spring 2024)</span> Gave invited talks about <a href="https://jykoh.com/vwa" target="_blank">VisualWebArena</a> at NUS, Jane Street, and Cohere for AI (<a href="https://www.youtube.com/watch?v=PmWDEqkVnqg" target="_blank">recording</a>).</li>
+          <li><span class="news-date">(Feb 2024)</span> Awarded the <a href="https://www.janestreet.com/join-jane-street/programs-and-events/grf-profiles-2024/" target="_blank">Jane Street Graduate Research Fellowship</a>. Thank you Jane Street!</li>
+          <li><span class="news-date">(Jan 2024)</span> Excited to share a new preprint: <a href="https://jykoh.com/vwa" target="_blank">VisualWebArena: Evaluating Multimodal Agents on Realistic Visual Web Tasks</a>.</li>
+          <li><span class="news-date">(Sep 2023)</span> 1 paper accepted to <a href="https://neurips.cc" target="_blank">NeurIPS 2023</a>!</li>
+          <li><span class="news-date">(Summer 2023)</span> Gave an invited talk about <a href="/gill" target="_blank">GILL</a> at <a href="https://mlcollective.org/dlct/" target="_blank">DLCT</a> and <a href="https://cohere.for.ai/" target="_blank">Cohere For AI</a> (<a href="/gill/gill_talk.pdf" target="_blank">slides</a>, <a href="https://www.youtube.com/watch?v=aUoiQ4xFknQ" target="_blank">recording</a>).</li>
+          <li><span class="news-date">(Apr 2023)</span> 1 paper accepted to <a href="https://icml.cc" target="_blank">ICML 2023</a>!</li>
+          <li><span class="news-date">(Spring 2023)</span> Gave invited talks at Microsoft Research, Apple AI/ML, Georgia Tech, and the London ML Meetup (<a href="https://www.youtube.com/watch?v=WNIjb96GvxU" target="_blank">recording</a>, <a href="fromage/fromage_talk.pdf" target="_blank">slides</a>).</li>
+          <li class="wrap-collabsible">
+            <input id="collapsible" class="toggle" type="checkbox">
+            <label for="collapsible" class="lbl-toggle">Older news</label>
+            <div class="collapsible-content">
+              <div class="content-inner">
+                <ul>
+                  <li><span class="news-date">(Dec 2022)</span> I made a <a href="https://benchugg.com/writing/ai-bet/" target="_blank">bet on LLM capabilities</a> with my office mate Ben Chugg. Bubble tea is on the line.</li>
+                  <li><span class="news-date">(Nov 2022)</span> <a href="https://parti.research.google" target="_blank">Parti</a> was accepted to TMLR with a Featured Certification!</li>
+                  <li><span class="news-date">(Oct 2022)</span> In the spirit of paying it forward, I'm sharing my <a href="jykoh_sop.pdf" target="_blank">Statement of Purpose</a> publicly. Hope it helps future applicants!</li>
+                  <li><span class="news-date">(Jul 2022)</span> After 2.73 wonderful years at Google, I've left to pursue my PhD at Carnegie Mellon University!</li>
+                  <li><span class="news-date">(January 2022)</span> 1 paper accepted to <a href="https://iclr.cc" target="_blank">ICLR 2022</a>!</li>
+                  <li><span class="news-date">(December 2021)</span> Serving as a reviewer for <a href="https://cvpr2022.thecvf.com" target="_blank">CVPR 2022</a>.</li>
+                  <li><span class="news-date">(July 2021)</span> 1 paper accepted to <a href="http://iccv2021.thecvf.com" target="_blank">ICCV 2021</a>!</li>
+                  <li><span class="news-date">(July 2021)</span> Presenting an <a href="https://www.microsoft.com/en-us/research/video/grounded-visual-generation/" target="_blank">invited talk</a> at Microsoft Research.</li>
+                  <li><span class="news-date">(July 2021)</span> Serving as a reviewer for <a href="https://nips.cc/Conferences/2021/" target="_blank">NeurIPS 2021</a>.</li>
+                  <li><span class="news-date">(March 2021)</span> 1 paper accepted to <a href="http://cvpr2021.thecvf.com" target="_blank">CVPR 2021</a>!</li>
+                  <li><span class="news-date">(January 2021)</span> 1 paper accepted to <a href="https://iclr.cc" target="_blank">ICLR 2021</a>!</li>
+                  <li><span class="news-date">(October 2020)</span> 1 paper accepted to <a href="http://wacv2021.thecvf.com/" target="_blank">WACV 2021</a>!</li>
+                  <li><span class="news-date">(July 2020)</span> 1 paper accepted to <a href="https://eccv2020.eu" target="_blank">ECCV 2020</a>!</li>
+                  <li><span class="news-date">(October 2019)</span> Officially joined Google as an AI Resident in Mountain View, California.</li>
+                </ul>
+              </div>
             </div>
-          </div>
-        </div>
+          </li>
         </ul>
         </div>
         <br/>
@@ -120,11 +118,11 @@
         <hr>
         <h3>2025</h3>
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://jykoh.com/search-agents/paper.pdf" alt="Tree Search for Language Model Agents" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="search-agents/search_overview_trunc.png" alt="" /></a>
+          <a href="https://jykoh.com/search-agents/paper.pdf">
+            <img class="publication-img" src="search-agents/search_overview_trunc.png" alt="" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
         <div class="paper-block">
             <div class="paper-details">
@@ -133,7 +131,7 @@
                 <p class="paper-authors"><strong>Jing Yu Koh</strong>, Stephen McAleer, Daniel Fried, Ruslan Salakhutdinov</p>
                 <p class="paper-venue"><i>TMLR</i>, 2025.</p>
             </div>
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://jykoh.com/search-agents" target="_blank">Project Page</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://jykoh.com/search-agents/paper.pdf" target="_blank">PDF</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://github.com/kohjingyu/search-agents" target="_blank">Code & Data</a>
@@ -144,11 +142,11 @@
 
         <h3>2024</h3>
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/abs/2401.13649" alt="VisualWebArena: Evaluating Multimodal Agents on Realistic Visual Web Tasks" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="vwa/overview-small.png" alt="" /></a>
+          <a href="https://arxiv.org/abs/2401.13649">
+            <img class="publication-img" src="vwa/overview-small.png" alt="" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
         <div class="paper-block">
             <div class="paper-details">
@@ -158,7 +156,7 @@
                 <p class="paper-venue"><i>ACL</i>, 2024.</p>
                 <p class="paper-venue">As seen on: <a href="https://www.wired.com/story/fast-forward-tested-next-gen-ai-assistant/" target="_blank">Wired</a>.</p>
             </div>
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://jykoh.com/vwa" target="_blank">Project Page</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/abs/2401.13649" target="_blank">PDF</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://github.com/web-arena-x/visualwebarena/" target="_blank">Code & Data</a>
@@ -172,11 +170,11 @@
 
         <h3>2023</h3>
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/abs/2305.17216" alt="Generating Images with Multimodal Language Models" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="gill/dialogue-small.png" alt="Generating Images with Multimodal Language Models" /></a>
+          <a href="https://arxiv.org/abs/2305.17216">
+            <img class="publication-img" src="gill/dialogue-small.png" alt="Generating Images with Multimodal Language Models" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
         <div class="paper-block">
             <div class="paper-details">
@@ -184,7 +182,7 @@
                 <p class="paper-authors"><strong>Jing Yu Koh</strong>, Daniel Fried, Ruslan Salakhutdinov</p>
                 <p class="paper-venue"><i>NeurIPS</i>, 2023.</p>
             </div>
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://jykoh.com/gill" target="_blank">Project Page</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/abs/2305.17216" target="_blank">PDF</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://github.com/kohjingyu/gill" target="_blank">Code</a>
@@ -197,11 +195,11 @@
         </div>
 
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/abs/2301.13823" alt="Grounding Language Models to Images for Multimodal Inputs and Outputs" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="fromage/bird_chat.png" alt="Grounding Language Models to Images for Multimodal Inputs and Outputs" /></a>
+          <a href="https://arxiv.org/abs/2301.13823">
+            <img class="publication-img" src="fromage/bird_chat.png" alt="Grounding Language Models to Images for Multimodal Inputs and Outputs" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
         <div class="paper-block">
             <div class="paper-details">
@@ -209,7 +207,7 @@
                 <p class="paper-authors"><strong>Jing Yu Koh</strong>, Ruslan Salakhutdinov, Daniel Fried</p>
                 <p class="paper-venue"><i>ICML</i>, 2023.</p>
             </div>
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://jykoh.com/fromage" target="_blank">Project Page</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/abs/2301.13823" target="_blank">PDF</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://github.com/kohjingyu/fromage" target="_blank">Code</a>
@@ -223,11 +221,11 @@
 
 
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/abs/2302.06833" alt="VQ3D: Learning a 3D-Aware Generative Model on ImageNet" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="papers/vq3d.png" alt="VQ3D: Learning a 3D-Aware Generative Model on ImageNet" /></a>
+          <a href="https://arxiv.org/abs/2302.06833">
+            <img class="publication-img" src="papers/vq3d.png" alt="VQ3D: Learning a 3D-Aware Generative Model on ImageNet" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
         <div class="paper-block">
             <div class="paper-details">
@@ -235,7 +233,7 @@
                 <p class="paper-authors">Kyle Sargent, <strong>Jing Yu Koh</strong>, Han Zhang, Huiwen Chang, Charles Herrmann, Pratul Srinivasan, Jiajun Wu, Deqing Sun</p>
                 <p class="paper-venue"><i>ICCV (oral, best paper finalist)</i>, 2023.</p>
             </div>
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://kylesargent.github.io/vq3d" target="_blank">Project Page</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/abs/2302.06833" target="_blank">PDF</a>
         </div>
@@ -245,11 +243,11 @@
 
 
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/abs/2204.02960" alt="Simple and Effective Synthesis of Indoor 3D Scenes" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="papers/se3ds.png" alt="Simple and Effective Synthesis of Indoor 3D Scenes" /></a>
+          <a href="https://arxiv.org/abs/2204.02960">
+            <img class="publication-img" src="papers/se3ds.png" alt="Simple and Effective Synthesis of Indoor 3D Scenes" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
         <div class="paper-block">
             <div class="paper-details">
@@ -257,7 +255,7 @@
                 <p class="paper-authors"><strong>Jing Yu Koh*</strong>, Harsh Agrawal*, Dhruv Batra, Richard Tucker, Austin Waters, Honglak Lee, Yinfei Yang, Jason Baldridge, Peter Anderson (* denotes equal contribution)</p>
                 <p class="paper-venue"><i>AAAI</i>, 2023.</p>
             </div>
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/abs/2204.02960" target="_blank">PDF</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://github.com/google-research/se3ds" target="_blank">Code</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://www.youtube.com/watch?v=4fVG0vg7yXI" target="_blank">Video</a>
@@ -268,11 +266,11 @@
 
         <h3>2022</h3>
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/abs/2206.10789" alt="Scaling Autoregressive Models for Content-Rich Text-to-Image Generation" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="papers/parti-small.png" alt="Scaling Autoregressive Models for Content-Rich Text-to-Image Generation" /></a>
+          <a href="https://arxiv.org/abs/2206.10789">
+            <img class="publication-img" src="papers/parti-small.png" alt="Scaling Autoregressive Models for Content-Rich Text-to-Image Generation" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
         <div class="paper-block">
             <div class="paper-details">
@@ -280,7 +278,7 @@
                 <p class="paper-authors">Jiahui Yu, Yuanzhong Xu, <strong>Jing Yu Koh</strong>, Thang Luong, Gunjan Baid, Zirui Wang, Vijay Vasudevan, Alexander Ku, Yinfei Yang, Burcu Karagol Ayan, Ben Hutchinson, Wei Han, Zarana Parekh, Xin Li, Han Zhang, Jason Baldridge, Yonghui Wu</p>
                 <p class="paper-venue"><i>TMLR</i>, 2022.</p>
             </div>
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="http://parti.research.google" target="_blank">Website</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/abs/2206.10789" target="_blank">PDF</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://github.com/google-research/parti" target="_blank">GitHub</a>
@@ -291,11 +289,11 @@
 
         <h3>2021</h3>
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/pdf/2105.08756.pdf" alt="Pathdreamer: A World Model for Indoor Navigation" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="papers/pathdreamer-small.png" alt="Pathdreamer: A World Model for Indoor Navigation" /></a>
+          <a href="https://arxiv.org/pdf/2105.08756.pdf">
+            <img class="publication-img" src="papers/pathdreamer-small.png" alt="Pathdreamer: A World Model for Indoor Navigation" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
         <div class="paper-block">
             <div class="paper-details">
@@ -303,7 +301,7 @@
                 <p class="paper-authors"><strong>Jing Yu Koh</strong>, Honglak Lee, Yinfei Yang, Jason Baldridge, Peter Anderson</p>
                 <p class="paper-venue"><i>ICCV</i>, 2021.</p>
             </div>
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://ai.googleblog.com/2021/09/pathdreamer-world-model-for-indoor.html" target="_blank">Blog Post</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://google-research.github.io/pathdreamer" target="_blank">Project Page</a>
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/pdf/2105.08756.pdf" target="_blank">PDF</a>
@@ -316,11 +314,11 @@
         </div>
 
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/pdf/2110.04627.pdf" alt="Vector-quantized Image Modeling with Improved VQGAN" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="papers/vitvqgan.png" alt="Vector-quantized Image Modeling with Improved VQGAN" /></a>
+          <a href="https://arxiv.org/pdf/2110.04627.pdf">
+            <img class="publication-img" src="papers/vitvqgan.png" alt="Vector-quantized Image Modeling with Improved VQGAN" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
         <div class="paper-block">
             <div class="paper-details">
@@ -329,7 +327,7 @@
                 <p class="paper-venue"><i>ICLR</i>, 2022.</p>
             </div>
 
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/pdf/2110.04627.pdf" target="_blank">PDF</a>
         </div>
         </div>
@@ -337,11 +335,11 @@
         </div>
 
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/pdf/2101.04702.pdf" alt="Cross-Modal Contrastive Learning for Text-to-Image Generation" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="papers/xmcgan.png" alt="Cross-Modal Contrastive Learning for Text-to-Image Generation" /></a>
+          <a href="https://arxiv.org/pdf/2101.04702.pdf">
+            <img class="publication-img" src="papers/xmcgan.png" alt="Cross-Modal Contrastive Learning for Text-to-Image Generation" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
         <div class="paper-block">
             <div class="paper-details">
@@ -350,7 +348,7 @@
                 <p class="paper-venue"><i>CVPR</i>, 2021.</p>
             </div>
 
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/pdf/2101.04702.pdf" target="_blank">PDF</a> <a class="btn btn-sm btn-outline-secondary" href="https://github.com/google-research/xmcgan_image_generation" target="_blank">Code</a>
         </div>
         </div>
@@ -358,11 +356,11 @@
         </div>
 
         <!-- <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/pdf/2104.06697.pdf" alt="Revisiting hierarchical approach for persistent long-term video prediction" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="papers/hierarchical21.png" alt="Revisiting hierarchical approach for persistent long-term video prediction" /></a>
+          <a href="https://arxiv.org/pdf/2104.06697.pdf">
+            <img class="publication-img" src="papers/hierarchical21.png" alt="Revisiting hierarchical approach for persistent long-term video prediction" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
          <div class="paper-block">
             <div class="paper-details">
@@ -370,7 +368,7 @@
                 <p class="paper-authors">Wonkwang Lee, Whie Jung, Han Zhang, Ting Chen, <strong>Jing Yu Koh</strong>, Thomas Huang, Hyungsuk Yoon, Honglak Lee, Seunghoon Hong</p>
                 <p class="paper-venue">In <i>The International Conference on Learning Representations (ICLR)</i>, 2021.</p>
             </div>
-       <div class="">
+       <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/pdf/2104.06697.pdf">PDF</a> <a class="btn btn-sm btn-outline-secondary" href="https://github.com/1Konny/HVP">Code</a>
         </div>
         </div>
@@ -378,11 +376,11 @@
         </div> -->
 
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/pdf/2011.03775.pdf" alt="Text-to-Image Generation Grounded by Fine-Grained User Attention" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="papers/wacv21.png" alt="Text-to-Image Generation Grounded by Fine-Grained User Attention" /></a>
+          <a href="https://arxiv.org/pdf/2011.03775.pdf">
+            <img class="publication-img" src="papers/wacv21.png" alt="Text-to-Image Generation Grounded by Fine-Grained User Attention" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
          <div class="paper-block">
             <div class="paper-details">
@@ -391,7 +389,7 @@
                 <p class="paper-venue"><i>WACV</i>, 2021.</p>
             </div>
 
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/pdf/2011.03775.pdf" target="_blank">PDF</a> <a class="btn btn-sm btn-outline-secondary" href="https://github.com/google-research/trecs_image_generation" target="_blank">Dataset</a> <a class="btn btn-sm btn-outline-secondary" href="https://www.deeplearning.ai/the-batch/pictures-from-words-and-gestures/" target="_blank">The Batch Feature</a>
         </div>
         </div>
@@ -400,11 +398,11 @@
 
         <h3>2020</h3>
         <div class="row publication-div mb-4 box-shadow">
-        <a href="https://arxiv.org/pdf/2002.02634" alt="SideInfNet" />
         <div class="col-md-3 publication-img-div">
-        <img class="publication-img" src="papers/sideinfnet20.png" alt="SideInfNet" /></a>
+          <a href="https://arxiv.org/pdf/2002.02634">
+            <img class="publication-img" src="papers/sideinfnet20.png" alt="SideInfNet" />
+          </a>
         </div>
-        </a>
         <div class="col-md-9">
          <div class="paper-block">
             <div class="paper-details">
@@ -413,7 +411,7 @@
                 <p class="paper-venue"><i>ECCV</i>, 2020.</p>
             </div>
 
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://arxiv.org/pdf/2002.02634" target="_blank">PDF</a>
         <a class="btn btn-sm btn-outline-secondary" href="http://kohjingyu.com/sideinfnet/" target="_blank">Project Page</a>
         </div>
@@ -436,7 +434,7 @@
                 <p class="paper-venue">In <i>International Joint Conference on Artificial Intelligence (IJCAI)</i>, 2019.</p>
             </div>
 
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="https://www.ijcai.org/proceedings/2019/0813.pdf">PDF</a>
         </div>
         </div>
@@ -456,7 +454,7 @@
                 <p class="paper-authors">Gary Goh, <strong>Jing Yu Koh</strong>, Yue Zhang</p>
                 <p class="paper-venue">In <i>IEEE International Conference on Data Mining (ICDM) Workshops</i>, 2018.</p>
             </div>
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" href="papers/Twitter_Informed_ICDM2018.pdf">PDF</a>
         </div>
         </div>
@@ -475,7 +473,7 @@
                 <p class="paper-venue">In <i>The European Conference on Computer Vision (ECCV)</i>, 2018.</p>
             </div>
 
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" target="_blank" href="http://openaccess.thecvf.com/content_ECCV_2018/papers/Tian_Feng_Urban_Zoning_Using_ECCV_2018_paper.pdf">PDF</a>
         </div>
         </div>
@@ -494,7 +492,7 @@
                 <p class="paper-venue">In <i>39th German Conference on Pattern Recognition (GCPR)</i>, 2017.</p>
             </div>
 
-        <div class="">
+        <div class="publication-links">
         <a class="btn btn-sm btn-outline-secondary" target="_blank" href="https://arxiv.org/pdf/1606.09187.pdf">PDF</a>
         <a class="btn btn-sm btn-outline-secondary" target="_blank" href="papers/gcpr17-poster.png">Poster</a>
         </div>


### PR DESCRIPTION
## Summary
- replace deprecated alignment attributes and add alt text for profile image
- streamline news section with collapsible list and proper semantics
- group publication links in a flex container for cleaner buttons

## Testing
- `tidy -q -e index.html`


------
https://chatgpt.com/codex/tasks/task_e_68bdc2c5971083299d1b551ec32d2efe